### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,30 +3,25 @@
 	"version": "0.2.0",
 	"description": "Grunt plugin to combine the manifests of multiple CreateJS exported files.",
 	"main": "./tasks/manifests.js",
-	"author":
-	{
+	"author": {
 		"name": "Matt Karl",
 		"email": "matt@cloudkid.com"
 	},
 	"license": "MIT",
-	"repository":
-	{
+	"repository": {
 		"type": "git",
 		"url": "https://github.com/SpringRoll/grunt-createjs-manifests"
 	},
-	"dependencies":
-	{
+	"dependencies": {
 		"glob": "~5.0.3",
 		"lodash": "^3.6.0"
 	},
-	"devDependencies":
-	{
+	"devDependencies": {
 		"grunt-contrib-jshint": "~0.10.0",
 		"grunt-simple-version": "~0.2.0"
 	},
-	"peerDependencies":
-	{
-		"grunt": "~0.4.5"
+	"peerDependencies": {
+		"grunt": ">=0.4.0"
 	},
 	"keywords": [
 		"gruntplugin",
@@ -35,13 +30,11 @@
 		"flash",
 		"manifests"
 	],
-	"scripts":
-	{
+	"scripts": {
 		"test": "grunt test --verbose"
 	},
 	"readmeFilename": "README.md",
-	"bugs":
-	{
+	"bugs": {
 		"url": "https://github.com/SpringRoll/grunt-createjs-manifests/issues"
 	},
 	"homepage": "https://github.com/SpringRoll/grunt-createjs-manifests"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
